### PR TITLE
Incoming subscriptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-beta</version>
+        <version>4.2.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>subscription</artifactId>


### PR DESCRIPTION
# Introduction

The original implementation of the plugin intercepts the subscription requests as they are originating *from* the server *to* the receiving user.
Is it a valid strategy, however, it assumes the receiving user is/will be online. This means that the subscription will not be accepted until that user comes online.
If accepting the subscription is required immediately, the packet needs to be intercepted as it is received by the server (when it's incoming).

Additionally, as another security step, this PR checks if the target user is registered on the server.

# Known issues

* If the target user is not in the originating user's roster, an exception is thrown.
* Since the subscription request is only processed if the target user is registered on the server, it will probably not work with users from another domain.