### PR TITLE
Pre-approving subscriptions from the originating user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>subscription</artifactId>
     <name>Subscription Plugin</name>
     <description>Automatically accepts or rejects subscription requests</description>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.4-SNAPSHOT</version>
 
     <developers>
         <developer>

--- a/src/java/org/jivesoftware/openfire/plugin/SubscriptionPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SubscriptionPlugin.java
@@ -187,11 +187,8 @@ public class SubscriptionPlugin implements Plugin {
                         // Try to automatically give the remote party subscription
                         // to the requesting user. If it's not possible, ignore the error
                         acceptSubscription(fromJID, toJID);
-                        if (acceptSubscription(toJID, fromJID)) {
-                            // If the subscription is automatically accepted,
-                            // reject the packet so it's not handled by the server again
-                            throw new PacketRejectedException();
-                        }
+                        acceptSubscription(toJID, fromJID);
+                        throw new PacketRejectedException();
                     }
 
                     if (type.equals(REJECT)) {

--- a/src/java/org/jivesoftware/openfire/plugin/SubscriptionPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/SubscriptionPlugin.java
@@ -184,7 +184,14 @@ public class SubscriptionPlugin implements Plugin {
 
                     if (type.equals(ACCEPT)) {
                         log.debug("Accepting");
-                        acceptSubscription(toJID, fromJID);
+                        // Try to automatically give the remote party subscription
+                        // to the requesting user. If it's not possible, ignore the error
+                        acceptSubscription(fromJID, toJID);
+                        if (acceptSubscription(toJID, fromJID)) {
+                            // If the subscription is automatically accepted,
+                            // reject the packet so it's not handled by the server again
+                            throw new PacketRejectedException();
+                        }
                     }
 
                     if (type.equals(REJECT)) {
@@ -195,13 +202,13 @@ public class SubscriptionPlugin implements Plugin {
             }
         }
 
-        private void acceptSubscription(JID toJID, JID fromJID) throws PacketRejectedException {
+        private boolean acceptSubscription(JID toJID, JID fromJID) {
             if (getSubscriptionLevel().equals(LOCAL)) {
                 String toDomain = toJID.getDomain();
                 String fromDomain = fromJID.getDomain();
 
                 if (!toDomain.equals(serverName) || !fromDomain.equals(serverName)) {
-                    return;
+                    return false;
                 }
             }
 
@@ -215,6 +222,7 @@ public class SubscriptionPlugin implements Plugin {
             }
             if (isInRoster) {
                 // Simulate that the target user has accepted the presence subscription request
+                log.debug("{} is already in {}'s roster. Subscribing...", fromJID, toJID);
                 Presence presence = new Presence();
                 presence.setType(Presence.Type.subscribed);
 
@@ -222,8 +230,7 @@ public class SubscriptionPlugin implements Plugin {
                 presence.setFrom(toJID);
                 router.route(presence);
             }
-
-            throw new PacketRejectedException();
+            return isInRoster;
         }
 
         private void rejectSubscription(JID toJID, JID fromJID) throws PacketRejectedException {


### PR DESCRIPTION
Instead of trying to make the target user accept the subscription request (which might not work because the originating user might not be in their roster), pre-approve the target user for receiving presence from the originating user.

Additionally, also try to accept the original subscription request, but first check if the originating user is in the roster.

Finally, only throw a `PacketRejectedException` if the original subscription request is handled (accepted automatically).